### PR TITLE
Update Pusher.php

### DIFF
--- a/src/Websocket/Pusher.php
+++ b/src/Websocket/Pusher.php
@@ -68,7 +68,7 @@ class Pusher
         bool $broadcast,
         bool $assigned,
         string $event,
-        $message = null,
+        $message,
         $server
     )
     {


### PR DESCRIPTION
This style of function declaration [has been deprecated in PHP 8.0](https://www.php.net/manual/en/migration80.deprecated.php). Writing functions like this has never made sense, since all parameters (up to the last required one) would need to be specified when the function was called.